### PR TITLE
removed wrike section and added optional changelog section

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,7 +1,3 @@
-### Wrike: ###
-
-* [LINKS TO YOUR TICKET(S) GO HERE]
-
 ### Description: ###
 
 [A BRIEF DESCRIPTION OF YOUR CHANGES]
@@ -11,3 +7,6 @@
 - [ ] Assigned 2 or more reviewers
 - [ ] Added yourself as "Assignee"
 - [ ] Included labels such as "WIP", "Waiting for reviews", etc.
+
+### Changelog ###
+(Optional)


### PR DESCRIPTION
Removed Wrike and added the Changelog section to the PR template

_This should be mored AFTER we've added Dangerbot to our projects because we will not longer need the Wrike section_